### PR TITLE
Drop blueprint-compiler

### DIFF
--- a/de.schmidhuberj.DieBahn.json
+++ b/de.schmidhuberj.DieBahn.json
@@ -23,25 +23,6 @@
     },
     "modules": [
         {
-            "name": "blueprint-compiler",
-            "buildsystem": "meson",
-            "cleanup": [
-                "*"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "tag": "v0.18.0",
-                    "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^v([\\d.]+)$"
-                    },
-                    "commit": "07c9c9df9cd1b6b4454ecba21ee58211e9144a4b"
-                }
-            ]
-        },
-        {
             "name": "diebahn",
             "buildsystem": "meson",
             "sources": [


### PR DESCRIPTION
Blueprint compiler is now part of GNOME runtime 49.